### PR TITLE
Add an automatic release build workflow

### DIFF
--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -28,30 +28,7 @@ jobs:
 
       - name: Download OpenVR Dependencies
         run: |
-          echo "------------------------------------------------------------------"
-          echo " Will download latest versions of OpenVR dependencies from Github"
-          echo "------------------------------------------------------------------"
-
-          echo "Downloading: openvr_api.cs"
           curl -L -o openvr_api.cs https://raw.githubusercontent.com/ValveSoftware/openvr/master/headers/openvr_api.cs
-
-          echo "Downloading: openvr_api.dll"
-          curl -L -o openvr_api.dll https://github.com/ValveSoftware/openvr/raw/master/bin/win64/openvr_api.dll
-
-          echo "Downloading: openvr_api.dll.sig"
-          curl -L -o openvr_api.dll.sig https://github.com/ValveSoftware/openvr/raw/master/bin/win64/openvr_api.dll.sig
-
-          echo "Downloading: openvr_api.pdb"
-          curl -L -o openvr_api.pdb https://github.com/ValveSoftware/openvr/raw/master/bin/win64/openvr_api.pdb
-
-          echo "Downloading: libopenvr_api.so"
-          curl -L -o libopenvr_api.so https://github.com/ValveSoftware/openvr/raw/master/bin/linux64/libopenvr_api.so
-
-          echo "Downloading: libopenvr_api.so.dbg"
-          curl -L -o libopenvr_api.so.dbg https://github.com/ValveSoftware/openvr/raw/master/bin/linux64/libopenvr_api.so.dbg
-
-          echo "------------------------------------------------------------------"
-          echo "Done!"
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build-and-publish:
@@ -36,8 +37,25 @@ jobs:
       - name: Build the project
         run: dotnet build --configuration Release --no-restore
 
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          else
+            LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+            BASE_VERSION="${LATEST_TAG#v}"
+            MAJOR=$(echo $BASE_VERSION | cut -d. -f1)
+            MINOR=$(echo $BASE_VERSION | cut -d. -f2)
+            PATCH=$(echo $BASE_VERSION | cut -d. -f3)
+            NEXT_PATCH=$((PATCH + 1))
+            VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-preview.${{ github.run_number }}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Pack the project
-        run: dotnet pack --configuration Release --no-build -o ./nupkg
+        run: dotnet pack --configuration Release --no-build -o ./nupkg -p:Version=${{ steps.version.outputs.version }}
 
       - name: Upload package as artifact
         uses: actions/upload-artifact@v7
@@ -50,6 +68,17 @@ jobs:
         run: gh release upload ${{ github.event.release.tag_name }} ./nupkg/*.nupkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push package to GitHub Packages
+        if: github.event_name == 'push'
+        run: |
+          dotnet nuget add source \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            --store-password-in-clear-text \
+            --name github \
+            "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          dotnet nuget push ./nupkg/*.nupkg --source github --skip-duplicate
 
       - name: Push package to NuGet
         if: github.event_name == 'release'

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feature/add-release-pipeline
     tags:
       - 'v*.*.*'
   release:

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-          cache: true
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
     steps:
       - name: Checkout code
@@ -70,7 +72,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push package to GitHub Packages
-        if: github.event_name == 'push'
         run: |
           dotnet nuget add source \
             --username ${{ github.actor }} \
@@ -81,5 +82,5 @@ jobs:
           dotnet nuget push ./nupkg/*.nupkg --source github --skip-duplicate
 
       - name: Push package to NuGet
-        if: github.event_name == 'release'
-        run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        if: github.event_name == 'release' && env.NUGET_API_KEY != ''
+        run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ env.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -60,18 +60,21 @@ jobs:
         run: dotnet pack --configuration Release --no-build -o ./nupkg -p:Version=${{ steps.version.outputs.version }}
 
       - name: Upload package as artifact
+        id: upload-artifact
         uses: actions/upload-artifact@v7
         with:
           name: nuget-package
           path: ./nupkg/*.nupkg
 
       - name: Upload package to release
+        id: upload-release
         if: github.event_name == 'release'
         run: gh release upload ${{ github.event.release.tag_name }} ./nupkg/*.nupkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push package to GitHub Packages
+        id: push-github
         run: |
           dotnet nuget add source \
             --username ${{ github.actor }} \
@@ -82,5 +85,28 @@ jobs:
           dotnet nuget push ./nupkg/*.nupkg --source github --skip-duplicate
 
       - name: Push package to NuGet
+        id: push-nuget
         if: github.event_name == 'release' && env.NUGET_API_KEY != ''
         run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ env.NUGET_API_KEY }} --skip-duplicate
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## NuGet Package" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Links" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.upload-artifact.outcome }}" == "success" ]; then
+            echo "- [Artifact (this run)](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.push-github.outcome }}" == "success" ]; then
+            echo "- [GitHub Packages](https://github.com/${{ github.repository }}/pkgs/nuget/EasyOpenVR)" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.upload-release.outcome }}" == "success" ]; then
+            echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }})" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.push-nuget.outcome }}" == "success" ]; then
+            echo "- [NuGet.org](https://www.nuget.org/packages/EasyOpenVR/${{ steps.version.outputs.version }})" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -99,7 +99,7 @@ jobs:
           echo "### Links" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.upload-artifact.outcome }}" == "success" ]; then
-            echo "- [Artifact (this run)](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Artifact (this run)](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)" >> $GITHUB_STEP_SUMMARY
           fi
           if [ "${{ steps.push-github.outcome }}" == "success" ]; then
             echo "- [GitHub Packages](https://github.com/${{ github.repository }}/pkgs/nuget/EasyOpenVR)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - feature/add-release-pipeline
-    tags:
-      - 'v*.*.*'
   release:
     types: [created]
+
+permissions:
+  contents: write
 
 jobs:
   build-and-publish:
@@ -45,6 +45,12 @@ jobs:
           name: nuget-package
           path: ./nupkg/*.nupkg
 
+      - name: Upload package to release
+        if: github.event_name == 'release'
+        run: gh release upload ${{ github.event.release.tag_name }} ./nupkg/*.nupkg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push package to NuGet
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'release'
         run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -26,6 +26,33 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - name: Download OpenVR Dependencies
+        run: |
+          echo "------------------------------------------------------------------"
+          echo " Will download latest versions of OpenVR dependencies from Github"
+          echo "------------------------------------------------------------------"
+
+          echo "Downloading: openvr_api.cs"
+          curl -L -o openvr_api.cs https://raw.githubusercontent.com/ValveSoftware/openvr/master/headers/openvr_api.cs
+
+          echo "Downloading: openvr_api.dll"
+          curl -L -o openvr_api.dll https://github.com/ValveSoftware/openvr/raw/master/bin/win64/openvr_api.dll
+
+          echo "Downloading: openvr_api.dll.sig"
+          curl -L -o openvr_api.dll.sig https://github.com/ValveSoftware/openvr/raw/master/bin/win64/openvr_api.dll.sig
+
+          echo "Downloading: openvr_api.pdb"
+          curl -L -o openvr_api.pdb https://github.com/ValveSoftware/openvr/raw/master/bin/win64/openvr_api.pdb
+
+          echo "Downloading: libopenvr_api.so"
+          curl -L -o libopenvr_api.so https://github.com/ValveSoftware/openvr/raw/master/bin/linux64/libopenvr_api.so
+
+          echo "Downloading: libopenvr_api.so.dbg"
+          curl -L -o libopenvr_api.so.dbg https://github.com/ValveSoftware/openvr/raw/master/bin/linux64/libopenvr_api.so.dbg
+
+          echo "------------------------------------------------------------------"
+          echo "Done!"
+
       - name: Restore dependencies
         run: dotnet restore
 

--- a/.github/workflows/publish-nuget.yaml
+++ b/.github/workflows/publish-nuget.yaml
@@ -1,0 +1,43 @@
+name: Build & Publish NuGet Package
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*.*.*'
+  release:
+    types: [created]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+          cache: true
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build the project
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Pack the project
+        run: dotnet pack --configuration Release --no-build -o ./nupkg
+
+      - name: Upload package as artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget-package
+          path: ./nupkg/*.nupkg
+
+      - name: Push package to NuGet
+        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
+        run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "EasyUtils"]
+    path = EasyUtils
+    url = https://github.com/BOLL7708/EasyUtils.git

--- a/EasyOpenVR.csproj
+++ b/EasyOpenVR.csproj
@@ -5,6 +5,16 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>14</LangVersion>
+
+        <PackageId>EasyOpenVR</PackageId>
+        <Authors>BOLL7708</Authors>
+        <Description>This is a Class Library to make it easier to talk to the OpenVR API using the official C# headers</Description>
+        <PackageTags>openvr steamvr openvr-api</PackageTags>
+        <PackageProjectUrl>https://github.com/BOLL7708/EasyOpenVR</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/BOLL7708/EasyOpenVR</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,6 +26,11 @@
     <ItemGroup>
         <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
         <PackageReference Include="System.Text.Json" Version="10.0.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" />
+        <None Include="LICENSE.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds a github workflow that automatically builds a nuget package of the project and stores it as an artifact and pushes it to the github registry as a nightly build on any push to `master`.

The workflow is also triggered by the creation of a github `release`, which results in the same as a push to master, plus it also publishes the package to nuget.org if an API key is saved in the repository secrets as `NUGET_API_KEY`, and it attaches the package to the github release to easily reference a nuget package from a release.